### PR TITLE
Feat: add semantic version compare for different ingress api

### DIFF
--- a/stable/spark-history-server/templates/ingress.yaml
+++ b/stable/spark-history-server/templates/ingress.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.ingress.enabled -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "spark-history-server.fullname" . }}


### PR DESCRIPTION
According to this [doc](https://kubernetes.io/docs/reference/using-api/deprecation-guide/), the Ingress api version has been depreciated if the cluster's kube version is more 1.19.

With the help of [semverCompare](https://renehernandez.io/snippets/customize-api-version-helm-templates/), we can use it to compare the semantic version and decide which api version is suitable for the ingress api version.

Connected issue: https://github.com/Hyper-Mesh/spark-history-server/issues/9